### PR TITLE
Fix: build.gradle, remove eclipse.project.name

### DIFF
--- a/code/build.gradle
+++ b/code/build.gradle
@@ -53,8 +53,6 @@ sourceSets.test.java.srcDirs = ["desktop/test/"]
 project.ext.mainClassName = "desktop.MyGame"
 project.ext.assetsDir = new File("assets")
 
-eclipse.project.name = "pmdungeon-desktop"
-
 task run(dependsOn: classes, type: JavaExec) {
     mainClass = project.mainClassName
     classpath = sourceSets.main.runtimeClasspath


### PR DESCRIPTION
Fix: build.gradle, remove eclipse.project.name

Siehe auch: #88 

eclipse.project.name hatte ich noch übersehen